### PR TITLE
Transform project as library for publishing to crates.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+*.bin

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "llama_cpp_rs"
+version = "0.1.0"
+dependencies = [
+ "bindgen",
+ "cc",
+ "lazy_static",
+]
+
+[[package]]
 name = "log"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,14 +194,6 @@ name = "regex-syntax"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
-
-[[package]]
-name = "rust_llama_cpp"
-version = "0.1.0"
-dependencies = [
- "bindgen",
- "cc",
-]
 
 [[package]]
 name = "rustc-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
-name = "rust_llama_cpp"
+name = "llama_cpp_rs"
 version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+lazy_static = "1.4.0"
 
 [build-dependencies]
 cc = "1.0.79"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,12 @@
 [package]
+authors = ["mdrokz <mohammadmunshi@gmail.com>"]
 name = "llama_cpp_rs"
+description = "Rust bindings for LLAMA.CPP inference"
+categories = ["api-bindings","development-tools::ffi","development-tools::build-utils","science"]
+keywords = ["Machine Learning","API Bindings","LLAMA","LLAMA.CPP","Inference"]
+license-file = "LICENSE"
+readme = "README.md"
+repository = "https://github.com/mdrokz/rust-llama.cpp"
 version = "0.1.0"
 edition = "2021"
 
@@ -11,3 +18,7 @@ lazy_static = "1.4.0"
 [build-dependencies]
 cc = "1.0.79"
 bindgen = "0.66.1"
+
+[lib]
+name = "llama_cpp_rs"
+path = "src/lib.rs"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 go-skynet authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# rust_llama.cpp

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -503,36 +503,3 @@ pub extern "C" fn tokenCallback(state: *mut c_void, token: *const c_char) -> boo
 
     true
 }
-
-fn main() -> Result<(), Box<dyn Error>> {
-    let opts = ModelOptions::default();
-
-    // let llama = LLama::new(String::from("/home/mdrokz/Documents/Projects/docker/vicuna/models2/wizard-vicuna-13B.ggmlv3.q4_0.bin
-    // "), opts)?;
-    let llama = LLama::new(String::from("./wizard-vicuna-13B.ggmlv3.q4_0.bin"), &opts)?;
-
-    let mut predict_opts = PredictOptions {
-        ..Default::default()
-    };
-
-    // llama.load_state("./test.bin".into())?;
-
-    llama.predict(
-        "what are the national animals of india ?".into(),
-        &mut predict_opts,
-    )?;
-
-    llama.predict(
-        "What are the national birds of india ?".into(),
-        &mut predict_opts,
-    )?;
-    
-    llama.predict("Whats the first question i asked ?".into(), &mut predict_opts)?;
-
-
-    // llama.save_state("./test.bin".into())?;
-
-    println!("Hello, world!");
-
-    Ok(())
-}

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ pub struct LLama {
 }
 
 impl LLama {
-    pub fn new(model: String, opts: ModelOptions) -> Result<Self, Box<dyn Error>> {
+    pub fn new(model: String, opts: &ModelOptions) -> Result<Self, Box<dyn Error>> {
         let model_path = CString::new(model).unwrap();
 
         let main_gpu_cstr = CString::new(opts.main_gpu.clone()).unwrap();
@@ -94,7 +94,7 @@ impl LLama {
         Ok(())
     }
 
-    pub fn eval(&self, text: String, mut opts: PredictOptions) -> Result<(), Box<dyn Error>> {
+    pub fn eval(&self, text: String, opts: &mut PredictOptions) -> Result<(), Box<dyn Error>> {
         let c_str = CString::new(text.clone()).unwrap();
 
         let input = c_str.as_ptr();
@@ -189,7 +189,7 @@ impl LLama {
     pub fn token_embeddings(
         &self,
         tokens: Vec<i32>,
-        mut opts: PredictOptions,
+        opts: &mut PredictOptions,
     ) -> Result<Vec<f32>, Box<dyn Error>> {
         if !self.embeddings {
             return Err("model loaded without embeddings".into());
@@ -279,7 +279,7 @@ impl LLama {
     pub fn embeddings(
         &self,
         text: String,
-        mut opts: PredictOptions,
+        opts: &mut PredictOptions,
     ) -> Result<Vec<f32>, Box<dyn Error>> {
         if !self.embeddings {
             return Err("model loaded without embeddings".into());
@@ -377,7 +377,7 @@ impl LLama {
     pub fn predict(
         &self,
         text: String,
-        mut opts: PredictOptions,
+        opts: &mut PredictOptions,
     ) -> Result<String, Box<dyn Error>> {
         let c_str = CString::new(text.clone()).unwrap();
 
@@ -509,14 +509,28 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // let llama = LLama::new(String::from("/home/mdrokz/Documents/Projects/docker/vicuna/models2/wizard-vicuna-13B.ggmlv3.q4_0.bin
     // "), opts)?;
-    let llama = LLama::new(String::from("./wizard-vicuna-13B.ggmlv3.q4_0.bin"), opts)?;
+    let llama = LLama::new(String::from("./wizard-vicuna-13B.ggmlv3.q4_0.bin"), &opts)?;
+
+    let mut predict_opts = PredictOptions {
+        ..Default::default()
+    };
+
+    // llama.load_state("./test.bin".into())?;
 
     llama.predict(
         "what are the national animals of india ?".into(),
-        PredictOptions {
-            ..Default::default()
-        },
+        &mut predict_opts,
     )?;
+
+    llama.predict(
+        "What are the national birds of india ?".into(),
+        &mut predict_opts,
+    )?;
+    
+    llama.predict("Whats the first question i asked ?".into(), &mut predict_opts)?;
+
+
+    // llama.save_state("./test.bin".into())?;
 
     println!("Hello, world!");
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -12,13 +12,13 @@ pub struct ModelOptions {
     pub n_gpu_layers: i32,
     pub main_gpu: String,
     pub tensor_split: String,
-    pub numa: bool
+    pub numa: bool,
 }
 
 impl Default for ModelOptions {
     fn default() -> Self {
         Self {
-            context_size: 128,
+            context_size: 2048,
             seed: 0,
             f16_memory: true,
             m_lock: false,
@@ -60,7 +60,8 @@ pub struct PredictOptions {
     pub mirostat_tau: f32,
     pub penalize_nl: bool,
     pub logit_bias: String,
-    pub token_callback: Box<dyn Fn(String) -> bool>,
+    // pub token_callback: Option<Box<dyn Fn(String) -> bool>>,
+    pub token_callback: Option<fn(String) -> bool>,
 
     pub path_prompt_cache: String,
     pub m_lock: bool,
@@ -97,7 +98,7 @@ impl Default for PredictOptions {
             mirostat_tau: 5.0,
             penalize_nl: false,
             logit_bias: String::from(""),
-            token_callback: Box::new(|_| true),
+            token_callback: None,
             path_prompt_cache: String::from(""),
             m_lock: false,
             m_map: false,
@@ -188,7 +189,10 @@ impl PredictOptions {
         self.m_map = m_map;
     }
 
-    pub fn set_token_callback(&mut self, token_callback: Box<dyn Fn(String) -> bool>) {
+    // pub fn set_token_callback(&mut self, token_callback: Option<Box<dyn Fn(String) -> bool>>) {
+    //     self.token_callback = token_callback;
+    // }
+    pub fn set_token_callback(&mut self, token_callback: Option<fn(String) -> bool>) {
         self.token_callback = token_callback;
     }
 
@@ -200,11 +204,11 @@ impl PredictOptions {
         self.seed = seed;
     }
 
-    pub  fn set_threads(&mut self, threads: i32) {
+    pub fn set_threads(&mut self, threads: i32) {
         self.threads = threads;
     }
 
-    pub  fn set_tokens(&mut self, tokens: i32) {
+    pub fn set_tokens(&mut self, tokens: i32) {
         self.tokens = tokens;
     }
 


### PR DESCRIPTION
# Changes

- convert the project to a library
- add crates.io properties to Cargo.toml for publishing
- add LICENSE & README files
- add lazy_static for maintaining a global map of callbacks
- change callback type in `PredictOptions` struct
- implement rest of the methods to get embeddings from the model
- change build system to include os specific flags