### PR TITLE
fix bad examples link

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ fn main() {
 
 The examples contain dockerfiles to run them
 
-see [examples](https://github.com/mdrokz/rust-llama.cpp/examples/README.md)
+see [examples](https://github.com/mdrokz/rust-llama.cpp/blob/master/examples/README.md)
 
 ## TODO
 


### PR DESCRIPTION
PR fixes the examples link that currently goes to a 404 page.