### PR TITLE
Update to latest llama.cpp to allow usage of LLaMAv2 and GGUF models

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -104,7 +104,11 @@ fn compile_ggml(cx: &mut Build, cx_flags: &str) {
 
     cx.include("./llama.cpp")
         .file("./llama.cpp/ggml.c")
+        .file("./llama.cpp/ggml-alloc.c")
+	.file("./llama.cpp/k_quants.c")
         .cpp(false)
+	.define("_GNU_SOURCE", None)
+	.define("GGML_USE_K_QUANTS", None)
         .compile("ggml");
 }
 
@@ -137,7 +141,7 @@ fn compile_llama(cxx: &mut Build, cxx_flags: &str, out_path: &PathBuf, ggml_type
     }
 
     cxx.shared_flag(true)
-        .file("./llama.cpp/examples/common.cpp")
+        .file("./llama.cpp/common/common.cpp")
         .file("./llama.cpp/llama.cpp")
         .file("./binding.cpp")
         .cpp(true)
@@ -168,7 +172,7 @@ fn main() {
 
     let mut ggml_type = String::new();
 
-    cxx.include("./llama.cpp/examples").include("./llama.cpp");
+    cxx.include("./llama.cpp/common").include("./llama.cpp").include("./include_shims");
 
     if cfg!(feature = "opencl") {
         compile_opencl(&mut cx, &mut cxx);

--- a/include_shims/build-info.h
+++ b/include_shims/build-info.h
@@ -1,0 +1,7 @@
+#ifndef BUILD_INFO_H
+#define BUILD_INFO_H
+
+#define BUILD_NUMBER 899
+#define BUILD_COMMIT "41c6741"
+
+#endif // BUILD_INFO_H

--- a/src/options.rs
+++ b/src/options.rs
@@ -18,7 +18,7 @@ pub struct ModelOptions {
 impl Default for ModelOptions {
     fn default() -> Self {
         Self {
-            context_size: 2048,
+            context_size: 512,
             seed: 0,
             f16_memory: true,
             m_lock: false,


### PR DESCRIPTION
This pull request modifies the bindings and build process to allow linking to the latest llama.cpp commit, in the process allowing the usage of LLaMAv2 and the new GGUF format.
It has been tested with the following model: https://huggingface.co/TheBloke/Llama-2-7B-GGUF/blob/main/llama-2-7b.Q4_K_S.gguf