### PR TITLE
Add explicit C and C++ versions to compile calls

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -153,8 +153,8 @@ fn main() {
 
     compile_bindings(&out_path);
 
-    let mut cx_flags = String::from("");
-    let mut cxx_flags = String::from("");
+    let mut cx_flags = String::from("-std=c11");
+    let mut cxx_flags = String::from("-std=c++11");
 
     // check if os is linux
     // if so, add -fPIC to cxx_flags

--- a/build.rs
+++ b/build.rs
@@ -153,14 +153,14 @@ fn main() {
 
     compile_bindings(&out_path);
 
-    let mut cx_flags = String::from("-std=c11");
-    let mut cxx_flags = String::from("-std=c++11");
+    let mut cx_flags = String::from("");
+    let mut cxx_flags = String::from("");
 
     // check if os is linux
     // if so, add -fPIC to cxx_flags
     if cfg!(target_os = "linux") || cfg!(target_os = "macos") {
-        cx_flags.push_str(" -Wall -Wextra -Wpedantic -Wcast-qual -Wdouble-promotion -Wshadow -Wstrict-prototypes -Wpointer-arith -pthread -march=native -mtune=native");
-        cxx_flags.push_str(" -Wall -Wdeprecated-declarations -Wunused-but-set-variable -Wextra -Wpedantic -Wcast-qual -Wno-unused-function -Wno-multichar -fPIC -pthread -march=native -mtune=native");
+        cx_flags.push_str(" -std=c11 -Wall -Wextra -Wpedantic -Wcast-qual -Wdouble-promotion -Wshadow -Wstrict-prototypes -Wpointer-arith -pthread -march=native -mtune=native");
+        cxx_flags.push_str(" -std=c++11 -Wall -Wdeprecated-declarations -Wunused-but-set-variable -Wextra -Wpedantic -Wcast-qual -Wno-unused-function -Wno-multichar -fPIC -pthread -march=native -mtune=native");
     } else if cfg!(target_os = "windows") {
         cx_flags.push_str(" /W4 /Wall /wd4820 /wd4710 /wd4711 /wd4820 /wd4514");
         cxx_flags.push_str(" /W4 /Wall /wd4820 /wd4710 /wd4711 /wd4820 /wd4514");


### PR DESCRIPTION
This matches the build behavior of upsteam's cmake[^1] and zig[^2] builds and resolves #11.

[^1]: https://github.com/ggerganov/llama.cpp/blob/95bd60a0a69f57e9a2ff1269667ea484a1a9bb40/CMakeLists.txt#L140-L143
[^2]: https://github.com/ggerganov/llama.cpp/blob/95bd60a0a69f57e9a2ff1269667ea484a1a9bb40/build.zig#L64-L65