### PR TITLE
fix missized vec

### DIFF
--- a/binding.cpp
+++ b/binding.cpp
@@ -139,7 +139,7 @@ int eval(void *params_ptr, void *state_pr, char *text)
     return llama_eval(ctx, tokens.data(), n_prompt_tokens, n_past);
 }
 
-int llama_predict(void *params_ptr, void *state_pr, char *result, bool debug)
+int llama_predict(void *params_ptr, void *state_pr, char **result, bool debug)
 {
     gpt_params *params_p = (gpt_params *)params_ptr;
     llama_context *ctx = (llama_context *)state_pr;
@@ -547,7 +547,7 @@ end:
         llama_reset_timings(ctx);
     }
 
-    strcpy(result, res.c_str());
+    *result = strdup(res.c_str());
     return 0;
 }
 

--- a/binding.h
+++ b/binding.h
@@ -31,7 +31,7 @@ extern "C"
 
     void llama_binding_free_model(void *state);
 
-    int llama_predict(void *params_ptr, void *state_pr, char *result, bool debug);
+    int llama_predict(void *params_ptr, void *state_pr, char **result, bool debug);
 
 #ifdef __cplusplus
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -423,7 +423,7 @@ impl LLama {
 
         println!("count {}", reverse_count);
 
-        let mut out = Vec::with_capacity(opts.tokens as usize);
+        let mut out: *mut c_char = std::ptr::null_mut();
 
         let logit_bias_cstr = CString::new(opts.logit_bias.clone()).unwrap();
 
@@ -476,7 +476,7 @@ impl LLama {
                 opts.prompt_cache_ro,
             );
 
-            let ret = llama_predict(params, self.state, out.as_mut_ptr(), opts.debug_mode);
+            let ret = llama_predict(params, self.state, &mut out as _, opts.debug_mode);
 
             if ret != 0 {
                 return Err("Failed to predict".into());
@@ -484,7 +484,7 @@ impl LLama {
 
             llama_free_params(params);
 
-            let c_str: &CStr = CStr::from_ptr(out.as_mut_ptr());
+            let c_str: &CStr = CStr::from_ptr(out);
             let mut res: String = c_str.to_str().unwrap().to_owned();
 
             res = res.trim_start().to_string();


### PR DESCRIPTION
This PR changes the way data is passed back from C to rust, primarily to fix a heap overflow. The `out` vec is currently allocated with capacity = the number of tokens to predict, however the data copied into `out` is the full detokenized string, which always has length > the number of tokens. This means every `predict()` call with a specified token count overflows the `out` vec's heap allocation.