### PR TITLE
Fix compilation w/ metal feature enabled

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -160,7 +160,7 @@ fn compile_metal(cx: &mut Build, cxx: &mut Build, out_dir: &Path) {
         patched_ggml_metal_path
     };
 
-    cx.include("./llama.cpp/ggml-metal.h").file(ggml_metal_path);
+    cx.include("./llama.cpp").file(ggml_metal_path);
 }
 
 fn compile_llama(cxx: &mut Build, cxx_flags: &str, out_path: &PathBuf, ggml_type: &str) {

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::ffi::OsStr;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -172,9 +173,17 @@ fn compile_llama(cxx: &mut Build, cxx_flags: &str, out_path: &PathBuf, ggml_type
     cxx.object(ggml_obj);
 
     if !ggml_type.is_empty() {
-        let ggml_feature_obj =
-            PathBuf::from(&out_path).join(format!("llama.cpp/ggml-{}.o", ggml_type));
-        cxx.object(ggml_feature_obj);
+        let out_path_pf = PathBuf::from(&out_path);
+        let contains_ggml_type = |s: &&OsStr| {
+            let s = s.to_string_lossy();
+            s.contains(ggml_type) && s.ends_with(".o")
+        };
+        let obj_files = out_path_pf.iter().filter(contains_ggml_type);
+        let out_path_pf = out_path_pf.join("llama.cpp");
+        let obj_files = obj_files.chain(out_path_pf.iter().filter(contains_ggml_type));
+        for obj in obj_files {
+            cxx.object(obj);
+        }
     }
 
     cxx.shared_flag(true)
@@ -209,7 +218,9 @@ fn main() {
 
     let mut ggml_type = String::new();
 
-    cxx.include("./llama.cpp/common").include("./llama.cpp").include("./include_shims");
+    cxx.include("./llama.cpp/common")
+        .include("./llama.cpp")
+        .include("./include_shims");
 
     if cfg!(feature = "opencl") {
         compile_opencl(&mut cx, &mut cxx);


### PR DESCRIPTION
* Link against <hash>-ggml-metal.o file
When creating object file with `compile_metal`, the object file is `<some_hash_value>-ggml-metal.o`, not `ggml-metal.o` - looks like cc-rs does this in `objects_from_files` to avoid overwriting (in general) if files in subdirectories would produce objects with the same hash name.

Since we explicitly link against the ggml-{metal,cuda} etc. object files, have to be more general to find the object files.

* Update include path for `compile_metal` such that specifies directory (not the ggml-metal.h header specifically)