### PR TITLE
Fix CUDA on Windows

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 *.bin
 example_test/
+**/target/

--- a/build.rs
+++ b/build.rs
@@ -96,10 +96,13 @@ fn compile_cuda(cxx_flags: &str) {
             nvcc.flag(&format!("{}={}", env_flag.1, flag_split.next().unwrap()));
         }
     }
+    let compiler = nvcc.get_compiler();
+    if !compiler.is_like_msvc() {
+        nvcc.flag("-Wno-pedantic");
+    }
 
     nvcc.compiler("nvcc")
         .file("./llama.cpp/ggml-cuda.cu")
-        .flag("-Wno-pedantic")
         .include("./llama.cpp/ggml-cuda.h")
         .compile("ggml-cuda");
 }

--- a/build.rs
+++ b/build.rs
@@ -64,6 +64,11 @@ fn compile_cuda(cxx_flags: &str) {
         println!("cargo:rustc-link-lib={}", lib);
     }
 
+    let cxx_flags = cxx_flags.split_whitespace();
+    // Remove windows specific flags
+    #[cfg(target_os = "windows")]
+    let cxx_flags = cxx_flags.filter(|flag| !flag.starts_with('/'));
+
     let mut nvcc = cc::Build::new();
 
     let env_flags = vec![
@@ -78,7 +83,7 @@ fn compile_cuda(cxx_flags: &str) {
         nvcc.flag(nvcc_flag);
     }
 
-    for cxx_flag in cxx_flags.split_whitespace() {
+    for cxx_flag in cxx_flags {
         nvcc.flag(cxx_flag);
     }
 

--- a/build.rs
+++ b/build.rs
@@ -179,8 +179,7 @@ fn compile_ggml(cx: &mut Build, cx_flags: &str) {
         .cpp(false)
         .define("_GNU_SOURCE", None)
         .define("GGML_USE_K_QUANTS", None);
-    #[cfg(feature = "cuda")]
-    cx.define("GGML_USE_CUBLAS", None);
+
     cx.compile("ggml");
 }
 
@@ -295,6 +294,9 @@ fn main() {
     }
 
     if cfg!(feature = "cuda") {
+        cx.define("GGML_USE_CUBLAS", None);
+        cxx.define("GGML_USE_CUBLAS", None);
+        
         compile_ggml(&mut cx, &cx_flags);
 
         compile_cuda(&cxx_flags);

--- a/build.rs
+++ b/build.rs
@@ -119,8 +119,10 @@ fn compile_ggml(cx: &mut Build, cx_flags: &str) {
         .file("./llama.cpp/ggml-quants.c")
         .cpp(false)
         .define("_GNU_SOURCE", None)
-        .define("GGML_USE_K_QUANTS", None)
-        .compile("ggml");
+        .define("GGML_USE_K_QUANTS", None);
+    #[cfg(feature = "cuda")]
+    cx.define("GGML_USE_CUBLAS", None);
+    cx.compile("ggml");
 }
 
 fn compile_metal(cx: &mut Build, cxx: &mut Build, out_dir: &Path) {

--- a/build.rs
+++ b/build.rs
@@ -101,7 +101,7 @@ fn compile_cuda(cxx_flags: &str) {
         nvcc.flag("-Wno-pedantic");
     }
 
-    nvcc.compiler("nvcc")
+    nvcc.cuda(true)
         .file("./llama.cpp/ggml-cuda.cu")
         .include("./llama.cpp/ggml-cuda.h")
         .compile("ggml-cuda");

--- a/build.rs
+++ b/build.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 use cc::Build;
 
-fn compile_bindings(out_path: &PathBuf) {
+fn compile_bindings(out_path: &Path) {
     let bindings = bindgen::Builder::default()
         .header("./binding.h")
         .blocklist_function("tokenCallback")
@@ -14,7 +14,7 @@ fn compile_bindings(out_path: &PathBuf) {
         .expect("Unable to generate bindings");
 
     bindings
-        .write_to_file(&out_path.join("bindings.rs"))
+        .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings!");
 }
 
@@ -148,7 +148,7 @@ fn compile_cuda(cxx_flags: &str) {
     }
 
     for env_flag in env_flags {
-        let mut flag_split = env_flag.0.split("=");
+        let mut flag_split = env_flag.0.split('=');
         if let Ok(val) = std::env::var(flag_split.next().unwrap()) {
             nvcc.flag(&format!("{}={}", env_flag.1, val));
         } else {
@@ -232,7 +232,7 @@ fn compile_metal(cx: &mut Build, cxx: &mut Build, out_dir: &Path) {
     cx.include("./llama.cpp/ggml-metal.h").file(ggml_metal_path);
 }
 
-fn compile_llama(cxx: &mut Build, cxx_flags: &str, out_path: &PathBuf, ggml_type: &str) {
+fn compile_llama(cxx: &mut Build, cxx_flags: &str, out_path: &Path, ggml_type: &str) {
     for cxx_flag in cxx_flags.split_whitespace() {
         cxx.flag(cxx_flag);
     }
@@ -245,7 +245,7 @@ fn compile_llama(cxx: &mut Build, cxx_flags: &str, out_path: &PathBuf, ggml_type
     }
 
     if let Some(build_info) = generate_build_info(out_path) {
-        cxx.file(build_info.to_str().unwrap());
+        cxx.file(build_info.to_str().expect("Failed to convert path to string"));
     }
 
     cxx.shared_flag(true)

--- a/build.rs
+++ b/build.rs
@@ -53,20 +53,30 @@ fn compile_cuda(cxx_flags: &str) {
     println!("cargo:rustc-link-search=native=/opt/cuda/lib64");
 
     if let Ok(cuda_path) = std::env::var("CUDA_PATH") {
+        #[cfg(target_os = "linux")]
         println!(
             "cargo:rustc-link-search=native={}/targets/x86_64-linux/lib",
             cuda_path
         );
-    }
 
-    let libs = "cublas culibos cudart cublasLt pthread dl rt";
+        #[cfg(target_os = "windows")]
+        println!(
+            "cargo:rustc-link-search=native={}/lib/x64",
+            cuda_path
+        );
+    }
+    //culibos, pthread dl rt are only needed for linux
+    #[cfg(target_os = "linux")]
+    let libs = "cuda cublas culibos cudart cublasLt pthread dl rt";
+    #[cfg(target_os = "windows")]
+    let libs = "cuda cublas cudart cublasLt";
 
     for lib in libs.split_whitespace() {
         println!("cargo:rustc-link-lib={}", lib);
     }
 
     let cxx_flags = cxx_flags.split_whitespace();
-    // Remove windows specific flags
+    // Remove msvc specific flags
     #[cfg(target_os = "windows")]
     let cxx_flags = cxx_flags.filter(|flag| !flag.starts_with('/'));
 

--- a/build.rs
+++ b/build.rs
@@ -176,14 +176,11 @@ fn compile_llama(cxx: &mut Build, cxx_flags: &str, out_path: &PathBuf, ggml_type
         cxx.flag(cxx_flag);
     }
 
-    let ggml_obj = PathBuf::from(&out_path).join("llama.cpp/ggml.o");
-
-    cxx.object(ggml_obj);
+    println!("cargo:rustc-link-search={}", out_path.display());
+    println!("cargo:rustc-link-lib=ggml");
 
     if !ggml_type.is_empty() {
-        let ggml_feature_obj =
-            PathBuf::from(&out_path).join(format!("llama.cpp/ggml-{}.o", ggml_type));
-        cxx.object(ggml_feature_obj);
+        println!("cargo:rustc-link-lib=ggml-{}", ggml_type);
     }
 
     cxx.shared_flag(true)


### PR DESCRIPTION
#24 - Fix CUDA native build on Windows, so you don't have to rely on Docker

Minor fixes some common or linux specific code applied in the meantime.