### PR TITLE
fix build.rs to build under macOS

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -120,6 +120,7 @@ fn compile_cuda(cxx_flags: &str) {
     #[cfg(target_os = "windows")]
     let libs = "cuda cublas cudart cublasLt";
 
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
     for lib in libs.split_whitespace() {
         println!("cargo:rustc-link-lib={}", lib);
     }


### PR DESCRIPTION
Erroring out, like this:
```
error[E0425]: cannot find value `libs` in this scope
   --> build.rs:123:16
    |
123 |     for lib in libs.split_whitespace() {
    |                ^^^^ not found in this scope
```
during ```cargo build``` without this fix