### PR TITLE
Removed count println from predict(..) as per #28

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,8 +421,6 @@ impl LLama {
             pass = reverse_prompt.as_mut_ptr();
         }
 
-        println!("count {}", reverse_count);
-
         let mut out: *mut c_char = std::ptr::null_mut();
 
         let logit_bias_cstr = CString::new(opts.logit_bias.clone()).unwrap();


### PR DESCRIPTION
A simple removal of the `println!("count {}", reverse_count);` line from the `predict` function in [`src/lib.rs`](./src/lib.rs).

As per issue #28, there could be further usage of the [`log` crate](https://crates.io/crates/log), but until that is more generally added and utilized properly, I think that it makes the most sense to simply get rid of this for now.